### PR TITLE
feat: Newspaper Photobox feature + home hero carousel

### DIFF
--- a/src/app/(landing)/(core)/create/create-clientside.tsx
+++ b/src/app/(landing)/(core)/create/create-clientside.tsx
@@ -102,19 +102,27 @@ const CreatePage = () => {
     IAllTemplateResponse[] | null
   >(null);
 
+  // The `photobox-newspaper` template only exists on the backend as a hack so
+  // the /photobox-newspaper feature can persist its generated image through the
+  // standard `createContent` flow. It is NOT a real fill-in-a-form digital gift,
+  // so hide it from every /create template list.
+  const HIDDEN_TEMPLATE_SLUGS = ['photobox-newspaper'];
+  const excludeHidden = (list: IAllTemplateResponse[] | null) =>
+    list?.filter((tpl) => !HIDDEN_TEMPLATE_SLUGS.includes(tpl.slug)) ?? null;
+
   const handleGetTemplates = async () => {
     const data = await getOriginalTemplates();
     if (data.success) {
-      setTemplates(data.data);
+      setTemplates(excludeHidden(data.data));
       const dx = await getPopularTemplates();
       if (dx.success) {
-        setPopularTemplates(dx.data);
+        setPopularTemplates(excludeHidden(dx.data));
       } else {
         message.error(dx.message);
       }
       const gx = await getGraduationTemplates();
       if (gx.success) {
-        setGraduationTemplates(gx.data);
+        setGraduationTemplates(excludeHidden(gx.data));
       } else {
         message.error(gx.message);
       }

--- a/src/app/(landing)/(core)/photobox-newspaper/[id]/page.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/[id]/page.tsx
@@ -1,0 +1,57 @@
+import { getDetailContent } from '@/action/user-api';
+import LockScreen from '@/components/ui/lock-screen';
+import ResultActions from './result-actions';
+
+export default async function PhotoboxNewspaperViewer({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
+  const data = await getDetailContent(id);
+
+  if (!data?.data) {
+    return <div className="p-10 text-center">No data</div>;
+  }
+
+  let parsed: { image?: string; template?: string } = {};
+  try {
+    parsed = JSON.parse(data.data.detail_content_json_text);
+  } catch {
+    parsed = {};
+  }
+
+  // Same gating logic as the digital gift viewers (e.g. newspaperv3).
+  const lockedContent =
+    data.data.status === 'locked' || data.data.user_type === 'free';
+
+  const content = (
+    <main className="min-h-screen bg-[#f4f1ea] flex flex-col items-center gap-8 py-12 px-4">
+      {parsed.image ? (
+        <img
+          src={parsed.image}
+          alt="Bestie of The Week newspaper"
+          className="w-full max-w-4xl border border-[#1a1a1a] shadow-[0_10px_40px_rgba(0,0,0,0.12)]"
+        />
+      ) : (
+        <div className="p-10 text-center">Image unavailable</div>
+      )}
+      {parsed.image && <ResultActions url={parsed.image} />}
+    </main>
+  );
+
+  if (lockedContent) {
+    return (
+      <LockScreen
+        contentId={id}
+        initiallyLocked
+        lockVariant="subtle"
+        title="Content locked for free users"
+        message="Unlock to view and share this photobox newspaper. Upgrade your plan for full access.">
+        {content}
+      </LockScreen>
+    );
+  }
+
+  return content;
+}

--- a/src/app/(landing)/(core)/photobox-newspaper/[id]/result-actions.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/[id]/result-actions.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Button, message } from 'antd';
+import { Download, Link2 } from 'lucide-react';
+
+/** Download the composited newspaper image and copy the shareable link. */
+export default function ResultActions({ url }: { url: string }) {
+  const handleDownload = () => {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'memoify-photobox-newspaper.png';
+    link.click();
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      message.success('Link copied to clipboard');
+    } catch {
+      message.error('Could not copy the link');
+    }
+  };
+
+  return (
+    <div className="flex gap-[12px]">
+      <Button
+        onClick={handleDownload}
+        type="primary"
+        size="large"
+        className="!bg-[#E34013] !text-white !font-[600] flex items-center gap-2">
+        <Download size={18} />
+        Download
+      </Button>
+      <Button
+        onClick={handleCopy}
+        size="large"
+        className="!font-[600] flex items-center gap-2">
+        <Link2 size={18} />
+        Copy link
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(landing)/(core)/photobox-newspaper/page.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+import PhotoboxNewspaperPage from './photobox-newspaper-clientside';
+
+export const metadata: Metadata = {
+  title: 'Photobox Newspaper | Memoify',
+  description:
+    'Snap a live photo straight into a vintage newspaper frame — photobooth style. Capture, retake, and download your own "Bestie of The Week" front page.',
+  alternates: {
+    canonical: 'https://memoify.live/photobox-newspaper',
+  },
+};
+
+export default function Page() {
+  return <PhotoboxNewspaperPage />;
+}

--- a/src/app/(landing)/(core)/photobox-newspaper/photobox-newspaper-clientside.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/photobox-newspaper-clientside.tsx
@@ -1,0 +1,611 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Webcam from 'react-webcam';
+import { message, notification, Progress, Spin, Tooltip } from 'antd';
+import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import { v4 as uuidv4 } from 'uuid';
+import html2canvas from 'html2canvas';
+import dayjs from 'dayjs';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Camera, Download, RotateCcw, Newspaper, Contrast, LogIn } from 'lucide-react';
+
+import NavigationBar from '@/components/ui/navbar';
+import { useMemoifySession } from '@/app/session-provider';
+import { uploadImageClientSide } from '@/lib/upload';
+import { createContent, getAllTemplates } from '@/action/user-api';
+
+// Request a 4:3 stream; the slot is 16:9 so object-cover trims top/bottom.
+const videoConstraints = {
+  facingMode: 'user',
+  width: 1280,
+  height: 960,
+};
+
+// The photo slot's aspect ratio. Captures are center-cropped to exactly this
+// so their pixels already match the slot — html2canvas ignores `object-fit`
+// and would otherwise stretch a 4:3 frame to fill the 16:9 box on export.
+const SLOT_ASPECT = 16 / 9;
+
+type TemplateKey = 'broadsheet' | 'classic';
+
+// Per-template styling. The frame markup is shared; these tokens + flags drive
+// the look so a user can switch templates live, even after capturing.
+const TEMPLATES: Record<
+  TemplateKey,
+  {
+    label: string;
+    icon: typeof Newspaper;
+    paperBg: string;
+    ink: string;
+    photoBg: string;
+    photoFilter: string;
+    grainPaper: boolean;
+    grainPhoto: boolean;
+    mastheadClass: string;
+    displayClass: string;
+    bodyClass: string;
+    ruleWidth: string; // px for the thick section rules
+    dateline: boolean;
+    columnDivider: boolean;
+    // Per-template front-page copy.
+    brand: string; // small italic line above the masthead
+    eyebrowLeft: string;
+    eyebrowRight: string;
+    masthead: string; // big blackletter nameplate
+    quote: string; // pull-quote headline under the photo
+    body: [string, string]; // two body columns
+  }
+> = {
+  broadsheet: {
+    label: 'Aged Broadsheet',
+    icon: Newspaper,
+    paperBg: '#f4f1ea',
+    ink: '#1a1a1a',
+    photoBg: '#e8e2d6',
+    photoFilter: 'grayscale(1) sepia(0.42) contrast(1.12) brightness(1.02)',
+    grainPaper: true,
+    grainPhoto: true,
+    mastheadClass: 'blackletter-font',
+    displayClass: 'np-display',
+    bodyClass: 'np-body',
+    ruleWidth: '3px',
+    dateline: true,
+    columnDivider: true,
+    brand: 'Memoify',
+    eyebrowLeft: 'Special Frame',
+    eyebrowRight: 'Memoify Newspaper',
+    masthead: 'Love of The Week',
+    quote:
+      'Front-page proof that these two are hopelessly, happily, head-over-heels in love.',
+    body: [
+      `From the very first frame, it was never really about the photos — it was about the way they look at each other when they think no one is watching. Every glance, every laugh, every almost-kiss caught mid-pose told the same quiet little story: these two are completely, helplessly smitten.`,
+      `Between the playful poses and the candid in-betweens, they turned an ordinary afternoon into something straight out of a love story. No filters, no fuss — just two people who make each other ridiculously happy, and a front page lucky enough to hold the proof.`,
+    ],
+  },
+  classic: {
+    label: 'Classic B&W',
+    icon: Contrast,
+    paperBg: '#ffffff',
+    ink: '#000000',
+    photoBg: '#000000',
+    photoFilter: 'grayscale(1) contrast(1.05)',
+    grainPaper: false,
+    grainPhoto: false,
+    mastheadClass: 'blackletter-font',
+    displayClass: 'font-serif',
+    bodyClass: 'font-serif',
+    ruleWidth: '1px',
+    dateline: false,
+    columnDivider: false,
+    brand: 'Terbit Sejak 1998',
+    eyebrowLeft: 'Edisi Politik',
+    eyebrowRight: 'Harga Rp 5.000',
+    masthead: 'Suara Rakyat',
+    quote: 'Polemik Makan Bergizi Gratis: Janji Kenyang, Realita Bikin Pusing.',
+    body: [
+      `Program Makan Bergizi Gratis yang digadang-gadang menjadi solusi gizi nasional kembali menuai sorotan. Di sejumlah daerah, porsi yang sampai ke tangan siswa disebut tak sesuai janji — sayur layu, lauk seadanya, dan jadwal pengiriman yang kerap terlambat. Warga pun bertanya: ke mana sebenarnya arah anggaran jumbo yang katanya demi masa depan bangsa?`,
+      `Sejumlah vendor mengeluhkan pembayaran yang tersendat, sementara kabar dapur yang tutup di tengah jalan menambah panjang daftar persoalan. Pemerintah berdalih ini sekadar "penyesuaian di lapangan", namun di meja makan rakyat, polemik gizi gratis ini masih terasa jauh dari kata kenyang.`,
+    ],
+  },
+};
+
+const TEMPLATE_ORDER: TemplateKey[] = ['broadsheet', 'classic'];
+
+/** Center-crop a captured frame to the slot's 16:9 ratio (no color change). */
+const cropTo169 = (base64: string): Promise<string> =>
+  new Promise((resolve) => {
+    const img = new Image();
+    img.src = base64;
+    img.onload = () => {
+      const { width: iw, height: ih } = img;
+      let sw = iw;
+      let sh = ih;
+      let sx = 0;
+      let sy = 0;
+      if (iw / ih > SLOT_ASPECT) {
+        sw = ih * SLOT_ASPECT;
+        sx = (iw - sw) / 2;
+      } else {
+        sh = iw / SLOT_ASPECT;
+        sy = (ih - sh) / 2;
+      }
+      const canvas = document.createElement('canvas');
+      canvas.width = sw;
+      canvas.height = sh;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(base64);
+        return;
+      }
+      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+      resolve(canvas.toDataURL('image/jpeg', 0.95));
+    };
+  });
+
+/**
+ * Bake the selected template's photo treatment (filter + optional grain) into
+ * the bitmap, so the look survives the html2canvas export — which only
+ * partially supports CSS `filter`.
+ */
+const applyTreatment = (
+  base64: string,
+  filter: string,
+  grain: boolean
+): Promise<string> =>
+  new Promise((resolve) => {
+    const img = new Image();
+    img.src = base64;
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(base64);
+        return;
+      }
+      ctx.filter = filter;
+      ctx.drawImage(img, 0, 0);
+      if (grain) {
+        const px = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        for (let i = 0; i < px.data.length; i += 4) {
+          const n = (Math.random() - 0.5) * 26;
+          px.data[i] += n;
+          px.data[i + 1] += n;
+          px.data[i + 2] += n;
+        }
+        ctx.putImageData(px, 0, 0);
+      }
+      resolve(canvas.toDataURL('image/jpeg', 0.95));
+    };
+  });
+
+const PhotoboxNewspaperPage = () => {
+  const webcamRef = useRef<Webcam | null>(null);
+  const frameRef = useRef<HTMLDivElement | null>(null);
+
+  const [template, setTemplate] = useState<TemplateKey>('broadsheet');
+  const [rawCropped, setRawCropped] = useState<string | null>(null);
+  const [capturedImage, setCapturedImage] = useState<string | null>(null);
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [grain, setGrain] = useState<string | null>(null);
+
+  const session = useMemoifySession();
+  const router = useRouter();
+  const [api, contextHolder] = notification.useNotification();
+
+  const t = TEMPLATES[template];
+
+  // Generate a faint noise tile once on mount for the aged paper texture. A
+  // data-URI PNG (unlike an SVG noise filter) renders reliably in html2canvas.
+  useEffect(() => {
+    const tile = document.createElement('canvas');
+    tile.width = 120;
+    tile.height = 120;
+    const ctx = tile.getContext('2d');
+    if (!ctx) return;
+    const data = ctx.createImageData(120, 120);
+    for (let i = 0; i < data.data.length; i += 4) {
+      const v = 150 + Math.random() * 90;
+      data.data[i] = v;
+      data.data[i + 1] = v;
+      data.data[i + 2] = v;
+      data.data[i + 3] = Math.random() * 16; // very low alpha
+    }
+    ctx.putImageData(data, 0, 0);
+    setGrain(tile.toDataURL());
+  }, []);
+
+  // Re-treat the captured photo whenever it changes or the template switches.
+  useEffect(() => {
+    if (!rawCropped) {
+      setCapturedImage(null);
+      return;
+    }
+    let active = true;
+    applyTreatment(rawCropped, t.photoFilter, t.grainPhoto).then((out) => {
+      if (active) setCapturedImage(out);
+    });
+    return () => {
+      active = false;
+    };
+  }, [rawCropped, t.photoFilter, t.grainPhoto]);
+
+  const openNotification = (progress: number = 0, key: any) => {
+    api.open({
+      message: (
+        <p className="text-[14px] text-black font-[600]">
+          {progress < 100 ? `Uploading ${progress}%` : 'Uploading completed'}
+        </p>
+      ),
+      description: (
+        <div>
+          <Progress percent={progress} />
+        </div>
+      ),
+      duration: 2000,
+      key,
+    });
+  };
+
+  const capture = useCallback(async () => {
+    if (!webcamRef.current) return;
+    const shot = webcamRef.current.getScreenshot();
+    if (!shot) {
+      message.error('Could not access the camera. Please allow camera access.');
+      return;
+    }
+    const cropped = await cropTo169(shot);
+    setRawCropped(cropped);
+  }, []);
+
+  // 3-second countdown, then snap — mirrors the existing Photobox behaviour.
+  const handleCaptureClick = () => {
+    let count = 3;
+    setCountdown(count);
+    const interval = setInterval(() => {
+      count -= 1;
+      if (count > 0) {
+        setCountdown(count);
+      } else {
+        clearInterval(interval);
+        setCountdown(null);
+        capture();
+      }
+    }, 1000);
+  };
+
+  const handleRetake = () => setRawCropped(null);
+
+  const handleSave = async () => {
+    if (!capturedImage || !frameRef.current) {
+      message.error('Capture a photo first.');
+      return;
+    }
+    try {
+      setLoading(true);
+
+      // 1. Snapshot the whole designed newspaper to a single PNG.
+      const canvas = await html2canvas(frameRef.current, {
+        scale: 2,
+        useCORS: true,
+        backgroundColor: t.paperBg,
+        logging: false,
+      });
+      const base64 = canvas.toDataURL('image/png');
+
+      // 2. Upload to Cloudinary.
+      const key = uuidv4();
+      const uploaded = await uploadImageClientSide(
+        base64 as unknown as any,
+        'premium',
+        openNotification,
+        key
+      );
+      const imageUrl = uploaded.data;
+
+      // 3. Resolve our own template_id by slug (env-proof; the UUID differs
+      //    between staging and production). No template-picker in this flow.
+      const templates = await getAllTemplates();
+      const tpl = templates?.data?.find((x) => x.slug === 'photobox-newspaper');
+      if (!tpl) {
+        message.error('Could not save right now. Please try again later.');
+        return;
+      }
+
+      const payload = {
+        template_id: tpl.id,
+        detail_content_json_text: JSON.stringify({
+          image: imageUrl,
+          template,
+        }),
+        title: t.masthead,
+        caption: '',
+        date_scheduled: null,
+        dest_email: null,
+        is_scheduled: false,
+        status: 'published',
+      };
+
+      const res = await createContent(payload);
+      if (res.success && res.data) {
+        router.push(`/photobox-newspaper/${res.data}`);
+      } else {
+        message.error(res.message || 'Failed to save. Please try again.');
+      }
+    } catch {
+      message.error('Something went wrong while saving. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const phase: 'login' | 'capture' | 'review' = !session?.accessToken
+    ? 'login'
+    : rawCropped
+      ? 'review'
+      : 'capture';
+
+  return (
+    <div>
+      {contextHolder}
+      <Spin fullscreen spinning={loading} />
+
+      <div className="fixed top-0 left-0 w-full z-10">
+        <NavigationBar />
+      </div>
+
+      <div className="mt-[120px] pb-[160px]">
+        <div className="px-[20px] mx-auto max-w-6xl 2xl:max-w-7xl mb-[20px]">
+          <h1 className="text-[#1B1B1B] font-[600] text-[18px]">
+            Photobox Newspaper
+          </h1>
+          <p className="text-[#7B7B7B] text-[14px] font-[400]">
+            Strike a pose — your shot lands straight on the front page.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-center px-[20px]">
+          {/* The newspaper frame. The image slot holds the live camera while
+              shooting, then the frozen capture. frameRef is what html2canvas
+              snapshots on save. */}
+          <motion.div
+            key={template}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.35 }}
+            ref={frameRef}
+            className="w-full max-w-4xl border"
+            style={{
+              backgroundColor: t.paperBg,
+              color: t.ink,
+              borderColor: t.ink,
+              backgroundImage:
+                t.grainPaper && grain ? `url(${grain})` : undefined,
+            }}>
+            {/* Masthead */}
+            <div
+              className="px-8 pt-6 pb-5"
+              style={{
+                borderBottom: `${t.ruleWidth} solid ${t.ink}`,
+              }}>
+              <div
+                className={`${t.displayClass} text-center text-[17px] italic mb-1`}>
+                {t.brand}
+              </div>
+              <div
+                className={`flex justify-between items-end ${t.bodyClass} text-[12px] uppercase tracking-[0.18em]`}>
+                <span>{t.eyebrowLeft}</span>
+                <span>{t.eyebrowRight}</span>
+              </div>
+              <h2
+                className={`${t.mastheadClass} text-center text-[68px] leading-[1.1] mt-3 pb-1`}>
+                {t.masthead}
+              </h2>
+            </div>
+
+            {/* Dateline strip (broadsheet only) */}
+            {t.dateline && (
+              <div
+                className={`px-8 py-1.5 text-center ${t.bodyClass} text-[11px] uppercase tracking-[0.22em]`}
+                style={{ borderBottom: `1px solid ${t.ink}` }}>
+                Vol. 1 · No. 1 — Jakarta, {dayjs().format('dddd, DD MMMM YYYY')}{' '}
+                — Price 25¢
+              </div>
+            )}
+
+            {/* Image slot — live webcam or frozen capture */}
+            <div
+              className="relative w-full aspect-[16/9] overflow-hidden"
+              style={{
+                backgroundColor: t.photoBg,
+                borderBottom: `${t.ruleWidth} solid ${t.ink}`,
+              }}>
+              {capturedImage ? (
+                <img
+                  src={capturedImage}
+                  alt="Your newspaper photo"
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <Webcam
+                  ref={webcamRef}
+                  audio={false}
+                  mirrored
+                  screenshotFormat="image/jpeg"
+                  videoConstraints={videoConstraints}
+                  className="w-full h-full object-cover"
+                  style={{ filter: t.photoFilter }}
+                />
+              )}
+
+              {countdown !== null && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-white text-6xl font-bold">
+                  {countdown}
+                </div>
+              )}
+            </div>
+
+            {/* Pull quote */}
+            <div
+              className="px-8 py-6"
+              style={{ borderBottom: `1px solid ${t.ink}` }}>
+              <p
+                className={`${t.displayClass} font-bold text-center text-[32px] leading-tight`}>
+                &ldquo;{t.quote}&rdquo;
+              </p>
+            </div>
+
+            {/* Body columns */}
+            <div
+              className={`grid grid-cols-2 px-8 py-7 ${
+                t.columnDivider ? 'gap-0' : 'gap-8'
+              }`}>
+              {t.body.map((col, i) => (
+                <p
+                  key={i}
+                  className={`${t.bodyClass} text-[15px] leading-relaxed text-justify ${
+                    t.columnDivider ? (i === 1 ? 'pl-8' : 'pr-8') : ''
+                  }`}
+                  style={
+                    t.columnDivider && i === 1
+                      ? { borderLeft: `1px solid ${t.ink}` }
+                      : undefined
+                  }>
+                  {col}
+                </p>
+              ))}
+            </div>
+
+            {/* Footer */}
+            <div
+              className={`px-8 py-3 flex justify-between ${t.bodyClass} text-[12px] uppercase tracking-[0.18em]`}
+              style={{ borderTop: `${t.ruleWidth} solid ${t.ink}` }}>
+              <span>Vol. 1 — No. 1</span>
+              <span>{dayjs().format('DD MMM YYYY')}</span>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Floating dock toolbar */}
+      <motion.div
+        initial={{ y: 90, x: '-50%', opacity: 0 }}
+        animate={{ y: 0, x: '-50%', opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className="fixed bottom-6 left-1/2 z-50 flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-[0_10px_40px_rgba(0,0,0,0.15)]">
+        {/* Template switcher */}
+        <div className="flex items-center gap-1 rounded-xl bg-[#f4f1ea] p-1">
+          {TEMPLATE_ORDER.map((key) => {
+            const cfg = TEMPLATES[key];
+            const Icon = cfg.icon;
+            const active = template === key;
+            return (
+              <Tooltip key={key} title={cfg.label}>
+                <button
+                  onClick={() => setTemplate(key)}
+                  className="relative flex h-9 w-9 items-center justify-center rounded-lg transition-colors"
+                  aria-label={cfg.label}>
+                  {active && (
+                    <motion.span
+                      layoutId="tpl-active"
+                      className="absolute inset-0 rounded-lg bg-[#E34013]"
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    />
+                  )}
+                  <Icon
+                    size={18}
+                    className={`relative z-10 ${active ? 'text-white' : 'text-black/55'}`}
+                  />
+                </button>
+              </Tooltip>
+            );
+          })}
+        </div>
+
+        <span className="mx-1 h-7 w-px bg-black/10" />
+
+        {/* Actions */}
+        <AnimatePresence mode="wait">
+          {phase === 'login' && (
+            <motion.div
+              key="login"
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: 0.18 }}>
+              <Tooltip title="Continue with Google to capture">
+                <motion.button
+                  whileHover={{ scale: 1.06 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => signIn('google')}
+                  className="flex h-10 items-center gap-2 rounded-xl bg-[#E34013] px-4 text-[14px] font-[600] text-white">
+                  <LogIn size={18} />
+                  Sign in
+                </motion.button>
+              </Tooltip>
+            </motion.div>
+          )}
+
+          {phase === 'capture' && (
+            <motion.div
+              key="capture"
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: 0.18 }}>
+              <Tooltip title="Capture">
+                <motion.button
+                  whileHover={{ scale: 1.08 }}
+                  whileTap={{ scale: 0.93 }}
+                  onClick={handleCaptureClick}
+                  disabled={countdown !== null}
+                  className="flex h-11 w-11 items-center justify-center rounded-full bg-[#E34013] text-white disabled:opacity-50"
+                  aria-label="Capture">
+                  <Camera size={20} />
+                </motion.button>
+              </Tooltip>
+            </motion.div>
+          )}
+
+          {phase === 'review' && (
+            <motion.div
+              key="review"
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: 0.18 }}
+              className="flex items-center gap-2">
+              <Tooltip title="Retake">
+                <motion.button
+                  whileHover={{ scale: 1.08 }}
+                  whileTap={{ scale: 0.93 }}
+                  onClick={handleRetake}
+                  className="flex h-10 w-10 items-center justify-center rounded-xl border border-black/10 bg-white text-black/70"
+                  aria-label="Retake">
+                  <RotateCcw size={18} />
+                </motion.button>
+              </Tooltip>
+              <Tooltip title="Save & continue">
+                <motion.button
+                  whileHover={{ scale: 1.06 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={handleSave}
+                  className="flex h-10 items-center gap-2 rounded-xl bg-[#E34013] px-4 text-[14px] font-[600] text-white"
+                  aria-label="Save and continue">
+                  <Download size={18} />
+                  Save
+                </motion.button>
+              </Tooltip>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
+};
+
+export default PhotoboxNewspaperPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 @import url('https://fonts.googleapis.com/css2?family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&display=swap');
 
 @font-face {
   font-family: 'Formula1 Display';
@@ -77,6 +78,28 @@
   font-family: "Inter", sans-serif;
   font-weight: 400;
   font-style: normal;
+}
+
+/* Two-slide hero carousel on the home page — make the dots visible on the
+   light/cream slide backgrounds and brand the active one. */
+.hero-carousel .slick-dots li button {
+  background: #1b1b1b !important;
+  opacity: 0.35;
+}
+.hero-carousel .slick-dots li.slick-active button {
+  background: #e34013 !important;
+  opacity: 1;
+}
+
+/* Aged-broadsheet type for the photobox-newspaper template. */
+.blackletter-font {
+  font-family: 'UnifrakturMaguntia', 'Playfair Display', serif;
+}
+.np-display {
+  font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+}
+.np-body {
+  font-family: 'Old Standard TT', 'PT Serif', Georgia, serif;
 }
 
 @tailwind base;

--- a/src/components/newlanding/NewLandingPage.tsx
+++ b/src/components/newlanding/NewLandingPage.tsx
@@ -40,6 +40,64 @@ import c3 from '@/assets/c3.png';
 import c4 from '@/assets/c4.png';
 const { Text } = Typography;
 
+// Sample editions shown in the Newspaper Photobox marquee. Alternates the two
+// real templates so visitors see the range (sweet broadsheet + viral satire).
+// TODO: replace the faux clipping cards below with real exported sample PNGs.
+const SAMPLE_EDITIONS = [
+  { masthead: 'Love of The Week', tone: 'broadsheet', tag: 'Memoify' },
+  { masthead: 'Suara Rakyat', tone: 'classic', tag: 'Edisi Politik' },
+  { masthead: 'Love of The Week', tone: 'broadsheet', tag: 'Memoify' },
+  { masthead: 'Suara Rakyat', tone: 'classic', tag: 'Edisi Politik' },
+  { masthead: 'Love of The Week', tone: 'broadsheet', tag: 'Memoify' },
+  { masthead: 'Suara Rakyat', tone: 'classic', tag: 'Edisi Politik' },
+];
+
+const CLIP_ROTATIONS = ['-rotate-2', 'rotate-1', '-rotate-1', 'rotate-2'];
+
+/** A faux mini newspaper front page used as a placeholder marquee clipping. */
+function NewspaperClipping({ edition, index }: { edition: any; index: number }) {
+  const broadsheet = edition.tone === 'broadsheet';
+  const ink = broadsheet ? '#1a1a1a' : '#000000';
+  return (
+    <div
+      className={`shrink-0 w-[260px] ${
+        CLIP_ROTATIONS[index % CLIP_ROTATIONS.length]
+      } transition-transform duration-300 hover:rotate-0 hover:scale-[1.03]`}>
+      <div
+        className="border overflow-hidden shadow-[0_14px_34px_rgba(0,0,0,0.18)]"
+        style={{ backgroundColor: broadsheet ? '#f4f1ea' : '#ffffff', borderColor: ink }}>
+        <div className="px-3 pt-3 pb-2" style={{ borderBottom: `2px solid ${ink}` }}>
+          <div
+            className="flex justify-between text-[7px] uppercase tracking-[0.15em]"
+            style={{ color: ink }}>
+            <span>Special Frame</span>
+            <span>{edition.tag}</span>
+          </div>
+          <h3
+            className="blackletter-font text-center leading-none mt-1 text-[22px]"
+            style={{ color: ink }}>
+            {edition.masthead}
+          </h3>
+        </div>
+        <div
+          className="w-full aspect-[16/9]"
+          style={{
+            background: broadsheet
+              ? 'linear-gradient(135deg,#d8cfbf,#bcae98)'
+              : 'linear-gradient(135deg,#cfcfcf,#9e9e9e)',
+            borderBottom: `2px solid ${ink}`,
+          }}
+        />
+        <div className="px-3 py-2 space-y-1">
+          <div className="h-[5px] w-[92%] rounded" style={{ backgroundColor: `${ink}33` }} />
+          <div className="h-[5px] w-[78%] rounded" style={{ backgroundColor: `${ink}26` }} />
+          <div className="h-[5px] w-[86%] rounded" style={{ backgroundColor: `${ink}26` }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function NewLandingPage() {
   const [email, setEmail] = useState('');
   const [faqLanguage, setFaqLanguage] = useState<'English' | 'Indonesia'>(
@@ -54,7 +112,58 @@ export default function NewLandingPage() {
 
       {/* Hero Section */}
       <div className="mt-[81px]">
-        <Reveal>
+        <Carousel
+          autoplay
+          autoplaySpeed={6000}
+          pauseOnHover
+          dots
+          className="hero-carousel">
+        {/* Slide 1 — Newspaper Photobox (inner wrapper so slick styling
+            doesn't override the layout) */}
+        <div>
+        <div
+          className="min-h-screen flex flex-col justify-center py-[60px]"
+          style={{ background: '#f4f1ea' }}>
+            {/* Centered intro */}
+            <div className="mx-auto max-w-3xl px-[20px] text-center">
+              <span className="inline-block text-[12px] font-[700] tracking-[0.2em] text-[#E34013] bg-[#FDECE5] rounded-full px-[14px] py-[6px]">
+                NEW · NEWSPAPER PHOTOBOX
+              </span>
+              <h2 className="text-[#1B1B1B] font-[800] text-[34px] md:text-[48px] leading-tight mt-[20px]">
+                You, hot off the press.
+              </h2>
+              <p className="text-[#5b5b5b] text-[16px] md:text-[19px] font-[400] mt-[16px]">
+                Strike a pose and watch your selfie drop straight onto a vintage
+                front page — sweet broadsheet or viral political satire. Capture,
+                pick your edition, download. No design skills, just main-character
+                energy.
+              </p>
+              <div className="flex items-center justify-center mt-[28px]">
+                <Link href={'/photobox-newspaper'} prefetch={true}>
+                  <Button
+                    iconPosition="end"
+                    size="large"
+                    icon={<ArrowRight size={18} />}
+                    className="!bg-[#E34013] !text-white !font-[600] !h-[46px]">
+                    Try Newspaper Photobox
+                  </Button>
+                </Link>
+              </div>
+            </div>
+
+            {/* Full-bleed auto-scrolling marquee of sample front pages */}
+            <div className="wedding-marquee mt-[50px]">
+              <div className="wedding-marquee-track wedding-marquee-track--left gap-[24px] py-[10px] px-[12px]">
+                {[...SAMPLE_EDITIONS, ...SAMPLE_EDITIONS].map((ed, i) => (
+                  <NewspaperClipping key={i} edition={ed} index={i} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Slide 2 — main hero (inner wrapper, same reason) */}
+        <div>
         <div className=" py-[30px] md:py-0 flex flex-col-reverse md:flex-row justify-between items-center mx-auto max-w-6xl 2xl:max-w-7xl px-[20px] min-h-screen">
           <div className="max-w-[600px] mr-[20px] flex-1 mt-[20px] md:mt-0">
             <div className="flex gap-[5px] border-[1px] border-[#D0D5DD] rounded-[6px] max-w-max p-[5px] text-[14px] text-[#1B1B1B] font-[500]">
@@ -95,7 +204,7 @@ export default function NewLandingPage() {
           <div className="flex-1 min-w-[350px] flex justify-center items-center">
             <Carousel
               autoplay
-              autoplaySpeed={5000}
+              autoplaySpeed={9000}
               className="w-[350px] md:w-[500px] lg:w-[600px]">
               <Image
                 src={mockup1}
@@ -121,7 +230,8 @@ export default function NewLandingPage() {
             </Carousel>
           </div>
         </div>
-        </Reveal>
+        </div>
+        </Carousel>
 
         {/* Photobox Section */}
         <Reveal>

--- a/src/components/ui/lock-screen.tsx
+++ b/src/components/ui/lock-screen.tsx
@@ -15,6 +15,12 @@ type LockScreenProps = {
   onUnlock?: () => void;
   contentId: string;
   type?: 'gift' | 'scrapbook';
+  /**
+   * 'default' — heavy dark veil over the content (standard digital gifts).
+   * 'subtle'  — faint dim + a floating card so the user can still SEE their
+   *             result clearly (but not interact). Used by /photobox-newspaper.
+   */
+  lockVariant?: 'default' | 'subtle';
 };
 
 const LockScreen = ({
@@ -26,7 +32,9 @@ const LockScreen = ({
   onUnlock,
   contentId,
   type = 'gift',
+  lockVariant = 'default',
 }: LockScreenProps) => {
+  const subtle = lockVariant === 'subtle';
   const profile = useMemoifyProfile();
   const isFreeAccount =
     type === 'gift' ? profile?.quota < 1 : profile?.token_scrapbook < 1;
@@ -66,27 +74,47 @@ const LockScreen = ({
   return (
     <div
       className={`relative isolate ${
-        type === 'gift' ? 'min-h-screen max-h-screen overflow-hidden' : ''
+        type === 'gift' && !subtle
+          ? 'min-h-screen max-h-screen overflow-hidden'
+          : ''
       }`}>
       <div
         className={`transition duration-300 ${
-          isLocked ? 'blur-[1.5px] pointer-events-none select-none' : ''
+          isLocked
+            ? `pointer-events-none select-none ${
+                subtle ? 'blur-[1px]' : 'blur-[1.5px]'
+              }`
+            : ''
         }`}>
         {children}
       </div>
 
       {isLocked && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/75 backdrop-blur-sm px-6 overflow-hidden">
-          <div className="max-w-md space-y-4 text-center text-white">
+        <div
+          className={`z-20 flex items-center justify-center px-6 overflow-hidden ${
+            subtle
+              ? 'fixed inset-0 bg-black/10 pointer-events-none'
+              : 'absolute inset-0 bg-black/75 backdrop-blur-sm'
+          }`}>
+          <div
+            className={`max-w-md space-y-4 text-center ${
+              subtle
+                ? 'bg-white text-black rounded-2xl shadow-2xl px-7 py-6 pointer-events-auto'
+                : 'text-white'
+            }`}>
             <h2 className="text-2xl font-semibold">{title}</h2>
-            <p className="text-sm text-gray-200">{message}</p>
+            <p className={`text-sm ${subtle ? 'text-gray-600' : 'text-gray-200'}`}>
+              {message}
+            </p>
             <div className="flex items-center justify-center gap-2">
               <Button
                 loading={lockedLoading}
                 onClick={handleUnlock}
                 type="primary"
                 size="middle"
-                className="!bg-white !text-black">
+                className={
+                  subtle ? '!bg-[#E34013] !text-white' : '!bg-white !text-black'
+                }>
                 {buttonText}
               </Button>{' '}
               <Button

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -35,9 +35,9 @@ import {
   House,
   LogOut,
   Menu,
+  Newspaper,
   Settings,
   Settings2,
-  Sparkles,
   Zap,
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -160,6 +160,28 @@ const NavigationBar = () => {
       ),
     },
     {
+      value: 'photobox-newspaper',
+      label: (
+        <div
+          className="flex items-start gap-2"
+          onClick={() => router.push('/photobox-newspaper')}>
+          <Newspaper size={18} className="text-[#E34013] mt-[10px]" />
+          <div>
+            <h1 className="text-[16px] font-[600] text-[#101828] text-ellipsis flex items-center gap-2">
+              Newspaper Photobox
+              <span className="text-[10px] font-[600] text-[#E34013] bg-[#FDECE5] rounded-full px-[8px] py-[2px]">
+                New
+              </span>
+            </h1>
+            <p className="text-[14px] font-[400] text-[#7B7B7B] mt-[2px]">
+              Snap a live selfie straight into a <br /> vintage newspaper front
+              page.
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
       value: 'gift',
       label: (
         <div
@@ -241,24 +263,25 @@ const NavigationBar = () => {
         </div>
       ),
     },
-    {
-      value: 'photobox',
-      label: (
-        <div
-          className="flex items-start gap-2"
-          onClick={() => router.push('/photobox')}>
-          <Sparkles size={18} className="text-[#E34013] mt-[10px]" />
-          <div>
-            <h1 className="text-[16px] font-[600] text-[#101828] text-ellipsis">
-              Photobox
-            </h1>
-            <p className="text-[14px] font-[400] text-[#7B7B7B] mt-[2px]">
-              Make every picture a keepsake <br /> with Memoify`s Photobox!
-            </p>
-          </div>
-        </div>
-      ),
-    },
+    // Photobox temporarily hidden — superseded by Newspaper Photobox above.
+    // {
+    //   value: 'photobox',
+    //   label: (
+    //     <div
+    //       className="flex items-start gap-2"
+    //       onClick={() => router.push('/photobox')}>
+    //       <Sparkles size={18} className="text-[#E34013] mt-[10px]" />
+    //       <div>
+    //         <h1 className="text-[16px] font-[600] text-[#101828] text-ellipsis">
+    //           Photobox
+    //         </h1>
+    //         <p className="text-[14px] font-[400] text-[#7B7B7B] mt-[2px]">
+    //           Make every picture a keepsake <br /> with Memoify`s Photobox!
+    //         </p>
+    //       </div>
+    //     </div>
+    //   ),
+    // },
   ];
 
   const options2 = [
@@ -277,6 +300,28 @@ const NavigationBar = () => {
             </h1>
             <p className="text-[12px] font-[400] text-[#7B7B7B] mt-[2px]">
               Design beautiful digital wedding <br /> invitations in minutes
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      value: 'photobox-newspaper',
+      label: (
+        <div
+          className="flex items-start gap-2"
+          onClick={() => router.push('/photobox-newspaper')}>
+          <Newspaper size={18} className="text-[#E34013] mt-[10px]" />
+          <div>
+            <h1 className="text-[14px] font-[600] text-[#101828] text-ellipsis flex items-center gap-2">
+              Newspaper Photobox
+              <span className="text-[10px] font-[600] text-[#E34013] bg-[#FDECE5] rounded-full px-[6px] py-[1px]">
+                New
+              </span>
+            </h1>
+            <p className="text-[12px] font-[400] text-[#7B7B7B] mt-[2px]">
+              Snap a live selfie straight into a <br /> vintage newspaper front
+              page.
             </p>
           </div>
         </div>
@@ -339,24 +384,25 @@ const NavigationBar = () => {
         </div>
       ),
     },
-    {
-      value: 'photobox',
-      label: (
-        <div
-          className="flex items-start gap-2"
-          onClick={() => router.push('/photobox')}>
-          <Sparkles size={18} className="text-[#E34013] mt-[10px]" />
-          <div>
-            <h1 className="text-[14px] font-[600] text-[#101828] text-ellipsis">
-              Photobox
-            </h1>
-            <p className="text-[12px] font-[400] text-[#7B7B7B] mt-[2px]">
-              Make every picture a keepsake <br /> with Memoify`s Photobox!
-            </p>
-          </div>
-        </div>
-      ),
-    },
+    // Photobox temporarily hidden — superseded by Newspaper Photobox above.
+    // {
+    //   value: 'photobox',
+    //   label: (
+    //     <div
+    //       className="flex items-start gap-2"
+    //       onClick={() => router.push('/photobox')}>
+    //       <Sparkles size={18} className="text-[#E34013] mt-[10px]" />
+    //       <div>
+    //         <h1 className="text-[14px] font-[600] text-[#101828] text-ellipsis">
+    //           Photobox
+    //         </h1>
+    //         <p className="text-[12px] font-[400] text-[#7B7B7B] mt-[2px]">
+    //           Make every picture a keepsake <br /> with Memoify`s Photobox!
+    //         </p>
+    //       </div>
+    //     </div>
+    //   ),
+    // },
   ];
 
   const handleGetProfile = async () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,14 @@ export function mapContentToCard(contents: IContent[], purpose = 'client') {
     // this function is used to get the jumbotron image from the json content
     //also check if the json content is an array and has at least one item
     const handleJumbotron = () => {
+      // photobox-newspaper stores its composited front page under `image`.
+      // Matched with includes() because its slug contains a dash, which the
+      // split('-')[1].split(' ')[1] extraction below would mangle into just
+      // "photobox" and drop the card.
+      if (show.template_name.includes('photobox-newspaper')) {
+        return jsonContent?.image;
+      }
+
       if (
         ['albumgraduation1'].includes(
           show.template_name.split('-')[1].split(' ')[1]
@@ -133,6 +141,8 @@ export function mapContentToCard(contents: IContent[], purpose = 'client') {
         : 'A title',
       link: show.template_name.includes('journal')
         ? `/journal/${show.id}`
+        : show.template_name.includes('photobox-newspaper')
+        ? `/photobox-newspaper/${show.id}`
         : `/${show.template_name.split('-')[1].split(' ')[1]}/${show.id}`,
       desc: show?.caption
         ? show?.caption


### PR DESCRIPTION
## Summary
Adds **Newspaper Photobox** (`/photobox-newspaper`) — a live-webcam photobooth that frames your selfie inside a vintage newspaper front page — plus a 2-slide auto-rotating hero on the home page to promote it.

## What's included
- **`/photobox-newspaper`** — live webcam rendered inside a real newspaper layout (WYSIWYG). Two templates switchable live: **Aged Broadsheet** (couple-themed "Love of The Week") and **Classic B&W** (satirical *Suara Rakyat* MBG edition). Capture → retake → save via a floating macOS-style dock toolbar.
- **Capture pipeline** — center-crop to 16:9 + baked sepia/grain (so the look survives `html2canvas`, which ignores `object-fit`/CSS filters on export).
- **Save (hack, no backend changes)** — composites the page → Cloudinary → `createContent`, resolving the real `photobox-newspaper` template by **slug** (env-proof; UUID differs staging/prod). Stores a minimal `{ image, template }` blob.
- **`/photobox-newspaper/[id]` viewer** — reads the blob, renders the image, Download + Copy-link. Gated like the digital gifts via `LockScreen`, with a new **`subtle`** variant (light dim, scrollable, fixed unlock card) so users can still see their result.
- **Dashboard support** — thumbnail + view link handled via `includes('photobox-newspaper')` to dodge the slug dash-splitting bug; template hidden from `/create` lists (it's a backend-only hack template).
- **Navbar** — old Photobox commented out; live "Newspaper Photobox" added under Wedding Invitations.
- **Home** — main hero + Newspaper Photobox become two slides of an auto-rotating `Carousel` (Newspaper shown first), with a full-bleed sample-front-page marquee. Inner hero images slowed so motions don't compete.

## Notes
- The home-page marquee uses **placeholder** front-page cards (`// TODO: replace with real exported sample PNGs`).
- Pre-existing repo-wide `eslint src/` debt is unrelated; all files touched here lint clean on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)