### PR TITLE
fix: lock gate reads status only; refresh Newspaper Photobox copy

### DIFF
--- a/src/app/(landing)/(core)/photobox-newspaper/[id]/page.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function PhotoboxNewspaperViewer({
 
   // Same gating logic as the digital gift viewers (e.g. newspaperv3).
   const lockedContent =
-    data.data.status === 'locked' || data.data.user_type === 'free';
+    data.data.status === 'locked';
 
   const content = (
     <main className="min-h-screen bg-[#f4f1ea] flex flex-col items-center gap-8 py-12 px-4">

--- a/src/app/(landing)/(core)/photobox-newspaper/photobox-newspaper-clientside.tsx
+++ b/src/app/(landing)/(core)/photobox-newspaper/photobox-newspaper-clientside.tsx
@@ -78,7 +78,7 @@ const TEMPLATES: Record<
     eyebrowRight: 'Memoify Newspaper',
     masthead: 'Love of The Week',
     quote:
-      'Front-page proof that these two are hopelessly, happily, head-over-heels in love.',
+      '“Front-page proof that these two are hopelessly, happily, head-over-heels in love.”',
     body: [
       `From the very first frame, it was never really about the photos — it was about the way they look at each other when they think no one is watching. Every glance, every laugh, every almost-kiss caught mid-pose told the same quiet little story: these two are completely, helplessly smitten.`,
       `Between the playful poses and the candid in-betweens, they turned an ordinary afternoon into something straight out of a love story. No filters, no fuss — just two people who make each other ridiculously happy, and a front page lucky enough to hold the proof.`,
@@ -100,18 +100,18 @@ const TEMPLATES: Record<
     dateline: false,
     columnDivider: false,
     brand: 'Terbit Sejak 1998',
-    eyebrowLeft: 'Edisi Politik',
+    eyebrowLeft: 'Memoify.live · Edisi Politik',
     eyebrowRight: 'Harga Rp 5.000',
     masthead: 'Suara Rakyat',
-    quote: 'Polemik Makan Bergizi Gratis: Janji Kenyang, Realita Bikin Pusing.',
+    quote: '#MENUJUINDONESIABANGKRUT KARENA MBG',
     body: [
-      `Program Makan Bergizi Gratis yang digadang-gadang menjadi solusi gizi nasional kembali menuai sorotan. Di sejumlah daerah, porsi yang sampai ke tangan siswa disebut tak sesuai janji — sayur layu, lauk seadanya, dan jadwal pengiriman yang kerap terlambat. Warga pun bertanya: ke mana sebenarnya arah anggaran jumbo yang katanya demi masa depan bangsa?`,
-      `Sejumlah vendor mengeluhkan pembayaran yang tersendat, sementara kabar dapur yang tutup di tengah jalan menambah panjang daftar persoalan. Pemerintah berdalih ini sekadar "penyesuaian di lapangan", namun di meja makan rakyat, polemik gizi gratis ini masih terasa jauh dari kata kenyang.`,
+      `Kami datang tanpa senjata. Tak membawa laras yang menganga, tak menyelipkan peluru di saku celana, tak menyusun strategi untuk merebut kuasa. Kami hanya mengenakan almamater semata, selembar kain yang menjelma cita-cita, yang dijahit dari uang orang tua, dan mimpi-mimpi tentang negeri yang lebih manusia. Kami datang dengan poster yang mulai pudar warnanya, dengan tenggorokan yang serak karena bertanya, dengan kaki yang rela menempuh panas kota, demi satu harapan sederhana, didengar suaranya.`,
+      `Bukankah kami seharusnya disambut dengan tawa? Dengan ruang dialog yang terbuka? Dengan tangan yang mengajak berbicara? Bukan dengan pagar besi yang ditinggikan berkali-kali lipatnya. Sebab kami bukan musuh negara. Kita lahir dari rahim yang sama, menghirup udara yang sama, dan tumbuh dari tanah yang sama. Kalau kami berdiri di jalan raya, itu karena terlalu banyak pintu yang terkunci rapat adanya. Kalau suara kami meninggi nadanya, itu karena terlalu lama jawaban disimpan dalam sunyi yang sengaja dipelihara. Maka dengarkanlah, sebelum sunyi itu tumbuh menjadi sesuatu yang tak lagi bisa kalian redam.`,
     ],
   },
 };
 
-const TEMPLATE_ORDER: TemplateKey[] = ['broadsheet', 'classic'];
+const TEMPLATE_ORDER: TemplateKey[] = ['classic', 'broadsheet'];
 
 /** Center-crop a captured frame to the slot's 16:9 ratio (no color change). */
 const cropTo169 = (base64: string): Promise<string> =>
@@ -186,7 +186,7 @@ const PhotoboxNewspaperPage = () => {
   const webcamRef = useRef<Webcam | null>(null);
   const frameRef = useRef<HTMLDivElement | null>(null);
 
-  const [template, setTemplate] = useState<TemplateKey>('broadsheet');
+  const [template, setTemplate] = useState<TemplateKey>('classic');
   const [rawCropped, setRawCropped] = useState<string | null>(null);
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
   const [countdown, setCountdown] = useState<number | null>(null);
@@ -455,7 +455,7 @@ const PhotoboxNewspaperPage = () => {
               style={{ borderBottom: `1px solid ${t.ink}` }}>
               <p
                 className={`${t.displayClass} font-bold text-center text-[32px] leading-tight`}>
-                &ldquo;{t.quote}&rdquo;
+                {t.quote}
               </p>
             </div>
 

--- a/src/app/(landing)/(gifts)/disneyplusv1/[slug]/page.tsx
+++ b/src/app/(landing)/(gifts)/disneyplusv1/[slug]/page.tsx
@@ -22,7 +22,6 @@ export default async function DynamicDisneyPage({ params }: { params: any }) {
   }
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
-  // const isFreeUser = data.data.user_type === 'free';
   const lockedContent = data.data.status === 'locked';
 
   const content = (

--- a/src/app/(landing)/(gifts)/magazinev1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/magazinev1/[id]/page.tsx
@@ -50,8 +50,7 @@ export default async function MagazineDetailV1({ params }: { params: any }) {
   }
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
-  const isFreeUser = data.data.user_type === 'free';
-  const lockedContent = data.data.status === 'locked' || isFreeUser;
+  const lockedContent = data.data.status === 'locked';
 
   const sentences = parsedData?.desc
     .split('.')

--- a/src/app/(landing)/(gifts)/netflixv1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/netflixv1/[id]/page.tsx
@@ -26,7 +26,7 @@ const RootUserPage = async ({ params }: any) => {
   if (!totalItems) return <div className="min-h-screen">No data</div>;
 
   const lockedContent =
-    data.data.status === 'locked' || data.data.user_type === 'free';
+    data.data.status === 'locked';
 
   const content = (
     <div className="bg-black overflow-x-hidden">

--- a/src/app/(landing)/(gifts)/newspaperv1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/newspaperv1/[id]/page.tsx
@@ -21,7 +21,7 @@ export default async function NewspaperPage({ params }: { params: any }) {
   }
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
-  const lockedContent = data.data.status === 'locked' || data.data.user_type === 'free';
+  const lockedContent = data.data.status === 'locked';
 
   const content = (
     <main className="min-h-screen bg-white">

--- a/src/app/(landing)/(gifts)/newspaperv3/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/newspaperv3/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function Home({ params }: { params: any }) {
   }
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
-  const lockedContent = data.data.status === 'locked' || data.data.user_type === 'free';
+  const lockedContent = data.data.status === 'locked';
   const selectedSongs = v3Songs.find((dx) => dx.id === parsedData.id);
 
   const contents = splitTextIntoColumns(parsedData.desc1);

--- a/src/app/(landing)/(gifts)/spotifyv1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/spotifyv1/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function HomePage({ params }: any) {
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
   const lockedContent =
-    data.data.status === 'locked' || data.data.user_type === 'free';
+    data.data.status === 'locked';
 
   const content = (
     <div className="h-screen bg-black">

--- a/src/app/(landing)/(gifts)/tarotv1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/tarotv1/[id]/page.tsx
@@ -29,7 +29,7 @@ const RootUserPage = async ({ params }: any) => {
   };
 
   const lockedContent =
-    data.data.status === 'locked' || data.data.user_type === 'free';
+    data.data.status === 'locked';
 
   const content = <TarotReader data={tarotData} />;
 

--- a/src/app/(landing)/(gifts)/vinylv1/[id]/page.tsx
+++ b/src/app/(landing)/(gifts)/vinylv1/[id]/page.tsx
@@ -17,7 +17,7 @@ export default async function VinylDynamicPage({ params }: any) {
 
   const parsedData = JSON.parse(data.data.detail_content_json_text);
   const lockedContent =
-    data.data.status === 'locked' || data.data.user_type === 'free';
+    data.data.status === 'locked';
 
   const content = (
     <VinylDynamic

--- a/src/app/(landing)/(scrapbooks)/scrapbook1/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook1/[id]/page.tsx
@@ -90,7 +90,7 @@ const ScrapbookResult = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook2/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook2/[id]/page.tsx
@@ -88,7 +88,7 @@ const ScrapbookVintageResult = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook3/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook3/[id]/page.tsx
@@ -89,7 +89,7 @@ const Scrapbook3Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook4/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook4/[id]/page.tsx
@@ -89,7 +89,7 @@ const Scrapbook4Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook5/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook5/[id]/page.tsx
@@ -90,7 +90,7 @@ const Scrapbook5Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook6/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook6/[id]/page.tsx
@@ -88,7 +88,7 @@ const Scrapbook6Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook7/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook7/[id]/page.tsx
@@ -89,7 +89,7 @@ const Scrapbook7Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}

--- a/src/app/(landing)/(scrapbooks)/scrapbook8/[id]/page.tsx
+++ b/src/app/(landing)/(scrapbooks)/scrapbook8/[id]/page.tsx
@@ -89,7 +89,7 @@ const Scrapbook7Result = async ({
           type="scrapbook"
           contentId={id}
           initiallyLocked={
-            data.data.status === 'locked' || data.data.user_type === 'free'
+            data.data.status === 'locked'
           }>
           <PageFlipScrapbook
             pages={structuredPages}


### PR DESCRIPTION
## Lock screen logic
Across **all gift + scrapbook viewers** (and `photobox-newspaper`), the lock gate now reads **only** `data.data.status === 'locked'` — the `user_type === 'free'` clause is removed.

New intended behaviour (backend-enforced):
- **Free template** → free users limited to 1×/day at **creation** (returns an error, *not* a lock; viewable result).
- **Premium template + free user** → unlimited creation but backend sets `status='locked'` → viewer locks.

So the frontend just trusts `status`. Also simplified `magazinev1` (dropped the `isFreeUser` var) and `disneyplusv1` (dropped a dead comment). Verified: **no `user_type` references left in `src/app`**.

17 viewers touched: netflixv1, spotifyv1, vinylv1, tarotv1, newspaperv1, newspaperv3, magazinev1, disneyplusv1, scrapbook1–8, photobox-newspaper.

## Newspaper Photobox copy
- **Classic B&W** is now the **default selected** template and **first** in the dock switcher.
- Classic edition copy:
  - Headline → `#MENUJUINDONESIABANGKRUT KARENA MBG`
  - Body → the *"Kami datang tanpa senjata…"* piece (2 columns + a coherent closing line)
  - Eyebrow → `Memoify.live · Edisi Politik` (source/watermark)
- Removed the hardcoded `&ldquo;…&rdquo;` wrapper around the pull-quote; quotes are now baked into the broadsheet copy so each template controls its own punctuation.

## Notes
- Pre-existing repo-wide `eslint src/` debt is unrelated; touched files lint clean on their own.
- Backend already sets `status='locked'` for premium+free (incl. backfill) and already surfaces the daily-limit error — confirmed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)